### PR TITLE
feat: increase max session length to 90 days

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
           cache: false
 
       - name: setup vips
-        run: sudo apt-get install -y libvips-tools && vips --version
+        run: sudo apt-get update && sudo apt-get install -y libvips-tools && vips --version
 
       - name: Install fake-oidc
         run: go install github.com/bradenrayhorn/fake-oidc@v0

--- a/server/src/core/session.rs
+++ b/server/src/core/session.rs
@@ -30,7 +30,7 @@ impl From<Error> for core::Error {
 }
 
 // maximum number of seconds a session may last before refresh
-pub const SESSION_EXPIRES_IN: i64 = 60 * 60 * 24;
+pub const SESSION_EXPIRES_IN: i64 = 60 * 60 * 90;
 
 pub struct Active {
     pub key: SessionKey,


### PR DESCRIPTION
This can still be limited by the expiration of the refresh token from the OIDC provider.