### PR TITLE
feat: update headers to make mobile experience nicer

### DIFF
--- a/e2e/tests/recipes/add.spec.ts
+++ b/e2e/tests/recipes/add.spec.ts
@@ -6,11 +6,12 @@ import { assertRecipeView, fillRecipeForm } from '@tests/helpers';
 test('can close page', async ({ login: _, page }) => {
   await page.goto('/recipes');
 
-  await page.getByRole('link', { name: 'Add', exact: true }).click();
+  await page.getByRole('button', { name: 'More options' }).click();
+  await page.getByRole('menuitem', { name: 'Add recipe', exact: true }).click();
 
-  await page.getByRole('link', { name: 'Back to previous page' }).click();
+  await page.getByRole('link', { name: 'Cancel' }).click();
 
-  await expect(page.getByLabel('Search')).toBeVisible();
+  await expect(page.getByRole('textbox', { name: 'Search' })).toBeVisible();
 });
 
 test('can add new simple recipe', async ({ login: user, page, request }) => {
@@ -18,9 +19,7 @@ test('can add new simple recipe', async ({ login: user, page, request }) => {
   await createTag({ user, request, name: 'Quick' });
 
   // go to add form
-  await page.goto('/recipes');
-
-  await page.getByRole('link', { name: 'Add', exact: true }).click();
+  await page.goto('/recipes/new');
 
   // fill out form
   await fillRecipeForm({
@@ -39,8 +38,8 @@ test('can add new simple recipe', async ({ login: user, page, request }) => {
   await page.getByRole('button', { name: 'Save' }).click();
 
   // back to recipes page
-  await page.getByLabel('Search').fill(`${user}Dinner`);
-  await page.getByLabel('Search').press('Enter');
+  await page.getByRole('textbox', { name: 'Search' }).fill(`${user}Dinner`);
+  await page.getByRole('textbox', { name: 'Search' }).press('Enter');
 
   await page.getByRole('link', { name: `${user}Dinner` }).click();
 
@@ -63,9 +62,7 @@ test('can add complex recipe', async ({ login: user, page, request }) => {
   await createTag({ user, request, name: 'Good' });
 
   // go to add form
-  await page.goto('/recipes');
-
-  await page.getByRole('link', { name: 'Add', exact: true }).click();
+  await page.goto('/recipes/new');
 
   // fill out form
   await fillRecipeForm({
@@ -84,8 +81,8 @@ test('can add complex recipe', async ({ login: user, page, request }) => {
   await page.getByRole('button', { name: 'Save' }).click();
 
   // back to recipes page
-  await page.getByLabel('Search').fill(`${user}Glazed Bread`);
-  await page.getByLabel('Search').press('Enter');
+  await page.getByRole('textbox', { name: 'Search' }).fill(`${user}Glazed Bread`);
+  await page.getByRole('textbox', { name: 'Search' }).press('Enter');
 
   await page.getByRole('link', { name: `${user}Glazed Bread` }).click();
 
@@ -108,9 +105,7 @@ test('can add recipe with minimal details', async ({ login: user, page, request 
   await createTag({ user, request, name: 'Good' });
 
   // go to add form
-  await page.goto('/recipes');
-
-  await page.getByRole('link', { name: 'Add', exact: true }).click();
+  await page.goto('/recipes/new');
 
   // fill out form
   await fillRecipeForm({
@@ -130,8 +125,8 @@ test('can add recipe with minimal details', async ({ login: user, page, request 
   await page.getByRole('button', { name: 'Save' }).click();
 
   // back to recipes page
-  await page.getByLabel('Search').fill(`${user}Glazed Bread`);
-  await page.getByLabel('Search').press('Enter');
+  await page.getByRole('textbox', { name: 'Search' }).fill(`${user}Glazed Bread`);
+  await page.getByRole('textbox', { name: 'Search' }).press('Enter');
 
   await page.getByRole('link', { name: `${user}Glazed Bread` }).click();
 

--- a/e2e/tests/recipes/edit.spec.ts
+++ b/e2e/tests/recipes/edit.spec.ts
@@ -7,8 +7,8 @@ test('can close page', async ({ login: user, page, request }) => {
   await createRecipe({ user, request, recipe: { title: 'A' } });
 
   await page.goto('/recipes');
-  await page.getByLabel('Search').fill(`${user}`);
-  await page.getByLabel('Search').press('Enter');
+  await page.getByRole('textbox', { name: 'Search' }).fill(`${user}`);
+  await page.getByRole('textbox', { name: 'Search' }).press('Enter');
 
   // to view page
   await page.getByRole('link', { name: `${user}A` }).click();
@@ -18,7 +18,7 @@ test('can close page', async ({ login: user, page, request }) => {
   await expect(page.getByRole('heading', { name: 'Edit Recipe' })).toBeVisible();
 
   // back to view page
-  await page.getByRole('link', { name: 'Back to previous page' }).click();
+  await page.getByRole('link', { name: 'Cancel' }).click();
   await expect(page.getByRole('heading', { name: `${user}A` })).toBeVisible();
 });
 

--- a/e2e/tests/recipes/list.spec.ts
+++ b/e2e/tests/recipes/list.spec.ts
@@ -63,8 +63,8 @@ test('can filter by tag and search', async ({ login: user, page, request, isMobi
   await expect(recipeList.getByRole('link')).toHaveText([`${user}Rho`, `${user}Tau`]);
 
   // add search for Rho
-  await page.getByLabel('Search').fill(`${user}Rho`);
-  await page.getByLabel('Search').press('Enter');
+  await page.getByRole('textbox', { name: 'Search' }).fill(`${user}Rho`);
+  await page.getByRole('textbox', { name: 'Search' }).press('Enter');
   await expect(recipeList.getByRole('link')).toHaveText([`${user}Rho`]);
 
   // remove Tag filter
@@ -155,8 +155,8 @@ test('mobile - can clear tag filters', async ({ login: user, page, request, isMo
   await page.goto('/recipes');
   const recipeList = page.getByRole('region', { name: 'Recipe list' });
 
-  await page.getByLabel('Search').fill(`${user}Rho`);
-  await page.getByLabel('Search').press('Enter');
+  await page.getByRole('textbox', { name: 'Search' }).fill(`${user}Rho`);
+  await page.getByRole('textbox', { name: 'Search' }).press('Enter');
 
   // add filter
   await addTagFilter({ page, user, isMobile, tags: ['Alpha', 'Beta'] });

--- a/e2e/tests/recipes/view.spec.ts
+++ b/e2e/tests/recipes/view.spec.ts
@@ -6,11 +6,11 @@ test('can close page', async ({ login: user, page, request }) => {
   await createRecipe({ user, request, recipe: { title: 'A' } });
 
   await page.goto('/recipes');
-  await page.getByLabel('Search').fill(`${user}`);
-  await page.getByLabel('Search').press('Enter');
+  await page.getByRole('textbox', { name: 'Search' }).fill(`${user}`);
+  await page.getByRole('textbox', { name: 'Search' }).press('Enter');
 
   await page.getByRole('link', { name: `${user}A` }).click();
-  await page.getByRole('link', { name: 'Back to previous page' }).click();
+  await page.getByRole('link', { name: 'Back' }).click();
 
-  await expect(page.getByLabel('Search')).toBeVisible();
+  await expect(page.getByRole('textbox', { name: 'Search' })).toBeVisible();
 });

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, user-scalable=no, viewport-fit=cover"
+    />
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />

--- a/ui/src/lib/actions/sticky.ts
+++ b/ui/src/lib/actions/sticky.ts
@@ -1,0 +1,26 @@
+import type { Action } from 'svelte/action';
+
+export const sticky: Action<HTMLElement> = (node) => {
+  let isStuck = window.scrollY > 0;
+  node.toggleAttribute('data-stuck', isStuck);
+
+  function onScroll() {
+    if (window.scrollY > 0 !== isStuck) {
+      isStuck = !isStuck;
+      requestAnimationFrame(() => {
+        node.toggleAttribute('data-stuck', isStuck);
+        for (const child of node.children) {
+          child.toggleAttribute('data-stuck', isStuck);
+        }
+      });
+    }
+  }
+
+  window.addEventListener('scroll', onScroll, { passive: true });
+
+  return {
+    destroy() {
+      window.removeEventListener('scroll', onScroll);
+    },
+  };
+};

--- a/ui/src/lib/components/CloseIconButton.svelte
+++ b/ui/src/lib/components/CloseIconButton.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-  import IconClose from '~icons/mdi/close-thick';
-
-  export let href: string;
-</script>
-
-<a class="rounded-full bg-alpha-100 text-alpha-700 p-1" {href} aria-label="Back to previous page"
-  ><IconClose /></a
->

--- a/ui/src/routes/about/+page.svelte
+++ b/ui/src/routes/about/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { sticky } from '$lib/actions/sticky';
+
   async function getUILicenses() {
     const res = await fetch('/licenses/ui-licenses.txt');
     const values = await res.text();
@@ -16,9 +18,14 @@
   const serverLicenses = getServerLicenses();
 </script>
 
-<h1 class="font-serif text-3xl font-bold px-4 py-6">About</h1>
+<h1
+  use:sticky
+  class="font-serif text-3xl font-bold px-4 pb-6 ptsafe-6 sticky top-0 transition-all bg-base-500 stuck:bg-base-600 stuck:shadow-md"
+>
+  About
+</h1>
 
-<div class="prose px-4">
+<div class="prose px-4 pbsafe-4">
   <p>mise is a self-hosted recipe service.</p>
 
   <p>

--- a/ui/src/routes/recipes/+page.svelte
+++ b/ui/src/routes/recipes/+page.svelte
@@ -2,7 +2,6 @@
   import IconChef from '~icons/mdi/chef-hat';
   import IconSad from '~icons/mdi/emoticon-sad-outline';
   import IconRight from '~icons/mdi/chevron-right';
-  import IconAdd from '~icons/mdi/plus';
   import StreamedError from '$lib/components/StreamedError.svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
@@ -15,6 +14,9 @@
   import { getRecipe, getRecipes } from '$lib/api/load/recipe';
   import { queryKeys } from '$lib/api/query-keys';
   import PrefetchLink from '$lib/components/PrefetchLink.svelte';
+  import OptionsMenu from './OptionsMenu.svelte';
+  import { sticky } from '$lib/actions/sticky';
+  import Search from './Search.svelte';
 
   const client = useQueryClient();
 
@@ -34,21 +36,43 @@
 
   $: hasSearch = search.trim().length > 0;
 
-  let searchValue = $page.url.searchParams.get('search') ?? '';
   $: tagValues = ($page.url.searchParams.get('tags') ?? '').split(',').filter((t) => t);
 </script>
 
 <div class="w-full min-h-dvh mx-auto flex flex-col justify-between">
-  <div class="p-4 mb-4 flex justify-between items-baseline">
-    <h1 class="font-bold text-3xl font-serif">Recipes</h1>
+  <div
+    use:sticky
+    class="ptsafe-4 p-4 sticky md:fixed transition-all top-0 left-0 right-0 bg-base-500 stuck:bg-base-600 stuck:shadow-md"
+  >
+    <div class="mb-4 md:mb-0 flex justify-between items-center gap-8">
+      <h1 class="font-bold text-3xl font-serif">Recipes</h1>
 
-    <a href="/recipes/new" class="text-sm btn-link text-fg-muted flex gap-2 items-center">
-      Add<IconAdd aria-hidden="true" />
-    </a>
+      <div class="grow hidden md:block"><Search /></div>
+
+      <OptionsMenu />
+    </div>
+
+    <div class="flex gap-4 md:hidden">
+      <Search />
+
+      <div class="items-center flex md:hidden">
+        <TagFilter
+          defaultTagSet={tagValues}
+          on:applied={(event) => {
+            goto(
+              `/recipes?${setQueryParameters(searchParams, { cursor: '', tags: event.detail.tag_ids.join(',') })}`,
+              {
+                invalidateAll: false,
+              },
+            );
+          }}
+        />
+      </div>
+    </div>
   </div>
 
   <div class="flex grow">
-    <div class="px-6 py-4 flex-col w-80 hidden md:flex">
+    <div class="px-6 py-4 flex-col w-80 hidden md:block md:fixed top-20">
       <div class="font-bold mb-4">Filter</div>
       <DesktopTagFilter
         defaultTagSet={tagValues}
@@ -63,121 +87,78 @@
       />
     </div>
 
-    <div class="flex flex-col justify-between h-full grow">
-      <div>
-        <div class="flex gap-2 px-4 md:py-4">
-          <form
-            class="grow"
-            method="POST"
-            on:submit={(e) => {
-              e.preventDefault();
-              goto(
-                `/recipes?${setQueryParameters(searchParams, { cursor: '', search: searchValue })}`,
-              );
-            }}
-          >
-            <input
-              type="text"
-              class="input"
-              aria-label="Search"
-              placeholder="Search"
-              bind:value={searchValue}
-            />
-
-            <button type="submit" class="hidden">Search</button>
-          </form>
-
-          <div class="items-center flex md:hidden">
-            <TagFilter
-              defaultTagSet={tagValues}
-              on:applied={(event) => {
-                goto(
-                  `/recipes?${setQueryParameters(searchParams, { cursor: '', tags: event.detail.tag_ids.join(',') })}`,
-                  {
-                    invalidateAll: false,
-                  },
-                );
-              }}
-            />
-          </div>
-        </div>
-
-        <div class="flex flex-col">
-          {#if $recipesQuery.status === 'pending'}
-            <div>Loading...</div>
-          {:else if $recipesQuery.status === 'error'}
-            <StreamedError error={$recipesQuery.error}>Could not load recipes.</StreamedError>
-          {:else}
-            <section class="flex flex-col pl-4 md:px-4" aria-label="Recipe list">
-              {#each $recipesQuery.data.data as recipe (recipe.id)}
-                <PrefetchLink
-                  class="flex items-center border-b-divider-default border-b py-3 pr-4 md:px-4 hover:bg-base-600 hover:shadow transition data-[loading]:bg-base-primaryHover data-[loading]:animate-pulse"
-                  href={`/recipes/${recipe.id}`}
-                  prefetch={async () => {
-                    await client.prefetchQuery({
-                      queryKey: queryKeys.recipe.get(recipe.id),
-                      queryFn: () => getRecipe({ fetch, id: recipe.id }),
-                    });
-                  }}
-                >
-                  {#if recipe.image_id}
-                    <img
-                      src={`/api/v1/images/${recipe.image_id}`}
-                      alt={recipe.title}
-                      class="w-16 h-16 shrink-0 object-cover shadow-inner rounded"
-                    />
-                  {:else}
-                    <div class="w-16 h-16 shrink-0 rounded overflow-hidden text-4xl">
-                      <RecipeImage title={recipe.title} />
-                    </div>
-                  {/if}
-                  <span class="ml-4 font-semibold line-clamp-2">{recipe.title}</span>
-                </PrefetchLink>
-              {:else}
-                <div class="flex flex-col items-center pt-12">
-                  <div class="flex flex-col items-center justify-center text-fg-muted mb-6">
-                    <IconChef class="text-6xl -mb-4 -ml-1" />
-                    <IconSad class="text-5xl" />
+    <div class="h-full grow md:ml-80 md:mt-20">
+      <div class="flex flex-col">
+        {#if $recipesQuery.status === 'pending'}
+          <div>Loading...</div>
+        {:else if $recipesQuery.status === 'error'}
+          <StreamedError error={$recipesQuery.error}>Could not load recipes.</StreamedError>
+        {:else}
+          <section class="flex flex-col pl-4 md:px-4" aria-label="Recipe list">
+            {#each $recipesQuery.data.data as recipe (recipe.id)}
+              <PrefetchLink
+                class="flex items-center border-b-divider-default border-b py-3 pr-4 md:px-4 hover:bg-base-600 hover:shadow transition data-[loading]:bg-base-primaryHover data-[loading]:animate-pulse"
+                href={`/recipes/${recipe.id}`}
+                prefetch={async () => {
+                  await client.prefetchQuery({
+                    queryKey: queryKeys.recipe.get(recipe.id),
+                    queryFn: () => getRecipe({ fetch, id: recipe.id }),
+                  });
+                }}
+              >
+                {#if recipe.image_id}
+                  <img
+                    src={`/api/v1/images/${recipe.image_id}`}
+                    alt={recipe.title}
+                    class="w-16 h-16 shrink-0 object-cover shadow-inner rounded"
+                  />
+                {:else}
+                  <div class="w-16 h-16 shrink-0 rounded overflow-hidden text-4xl">
+                    <RecipeImage title={recipe.title} />
                   </div>
-                  <span>Sorry, Chef.</span>
-                  <span>No recipes found.</span>
+                {/if}
+                <span class="ml-4 font-semibold line-clamp-2">{recipe.title}</span>
+              </PrefetchLink>
+            {:else}
+              <div class="flex flex-col items-center pt-12">
+                <div class="flex flex-col items-center justify-center text-fg-muted mb-6">
+                  <IconChef class="text-6xl -mb-4 -ml-1" />
+                  <IconSad class="text-5xl" />
                 </div>
-              {/each}
-            </section>
-
-            {#if hasSearch}
-              <div class="w-full py-5 text-center text-fg-muted">
-                Search only returns top results. Refine your search to see more results.
+                <span>Sorry, Chef.</span>
+                <span>No recipes found.</span>
               </div>
-            {/if}
+            {/each}
+          </section>
 
-            <div class="w-full flex justify-between py-3 px-4">
-              {#if hasCursor}
-                <a
-                  href={`/recipes?${setQueryParameters(searchParams, { cursor: '' })}`}
-                  class="text-sm btn-link">Back to first</a
-                >
-              {:else}
-                <div />
-              {/if}
-
-              {#if $recipesQuery.data.next}
-                <a
-                  class="flex items-center text-sm btn-link"
-                  href={`/recipes?${setQueryParameters(searchParams, { cursor: $recipesQuery.data.next })}`}
-                  >Next<IconRight /></a
-                >
-              {:else}
-                <div />
-              {/if}
+          {#if hasSearch}
+            <div class="w-full py-5 px-4 text-center text-fg-muted">
+              Search only returns top results. Refine your search to see more results.
             </div>
           {/if}
-        </div>
+
+          <div class="w-full flex justify-between pt-3 pbsafe-3 px-4">
+            {#if hasCursor}
+              <a
+                href={`/recipes?${setQueryParameters(searchParams, { cursor: '' })}`}
+                class="text-sm btn-link">Back to first</a
+              >
+            {:else}
+              <div />
+            {/if}
+
+            {#if $recipesQuery.data.next}
+              <a
+                class="flex items-center text-sm btn-link"
+                href={`/recipes?${setQueryParameters(searchParams, { cursor: $recipesQuery.data.next })}`}
+                >Next<IconRight /></a
+              >
+            {:else}
+              <div />
+            {/if}
+          </div>
+        {/if}
       </div>
     </div>
-  </div>
-  <div class="w-full px-4 py-4 mt-3 flex justify-between text-xs text-fg-muted">
-    <div>mise</div>
-    <a href="/settings" class="btn-link">Settings</a>
   </div>
 </div>

--- a/ui/src/routes/recipes/OptionsMenu.svelte
+++ b/ui/src/routes/recipes/OptionsMenu.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import IconOptions from '~icons/mdi/dots-horizontal-circle-outline';
+  import { createDropdownMenu, melt } from '@melt-ui/svelte';
+
+  const {
+    elements: { trigger, menu, item, separator },
+    states: { open },
+  } = createDropdownMenu({
+    preventScroll: false,
+  });
+</script>
+
+<button
+  use:melt={$trigger}
+  class="text-xl text-fg-muted"
+  data-active={$open}
+  aria-label="More options"
+>
+  <IconOptions aria-hidden="true" />
+</button>
+
+{#if open}
+  <div class="z-10 flex flex-col shadow rounded bg-base-600 py-2 text-sm" use:melt={$menu}>
+    <a
+      href="/recipes/new"
+      class="pl-3 pr-8 data-[highlighted]:bg-base-primaryHover py-1 text-left"
+      use:melt={$item}
+    >
+      Add recipe
+    </a>
+
+    <div class="h-px shrink-0 bg-divider-default my-2" use:melt={$separator} />
+
+    <a
+      href="/settings"
+      class="pl-3 pr-8 data-[highlighted]:bg-base-primaryHover py-1 text-left"
+      use:melt={$item}
+    >
+      Settings
+    </a>
+  </div>
+{/if}

--- a/ui/src/routes/recipes/Search.svelte
+++ b/ui/src/routes/recipes/Search.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
+  import { setQueryParameters } from '$lib/replace-query-parameter';
+
+  $: queryParams = $page.url.searchParams;
+  let searchValue = $page.url.searchParams.get('search') ?? '';
+
+  page.subscribe((newPage) => {
+    searchValue = newPage.url.searchParams.get('search') ?? '';
+  });
+</script>
+
+<form
+  class="grow"
+  method="POST"
+  on:submit={(e) => {
+    e.preventDefault();
+    goto(`/recipes?${setQueryParameters(queryParams, { cursor: '', search: searchValue })}`);
+  }}
+>
+  <input
+    type="text"
+    class="input"
+    aria-label="Search"
+    placeholder="Search"
+    bind:value={searchValue}
+  />
+
+  <button type="submit" class="hidden">Search</button>
+</form>

--- a/ui/src/routes/recipes/[id]/ViewRecipePage.svelte
+++ b/ui/src/routes/recipes/[id]/ViewRecipePage.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import IconLeft from '~icons/mdi/chevron-left';
+  import IconPencil from '~icons/mdi/pencil-outline';
   import SingleTag from '$lib/components/SingleTag.svelte';
-  import CloseIconButton from '$lib/components/CloseIconButton.svelte';
   import type { DetailedRecipe } from '$lib/types/recipe';
   import { uid } from 'uid';
+  import { sticky } from '$lib/actions/sticky';
 
   export let recipe: DetailedRecipe;
   export let backURL: string;
@@ -12,20 +14,33 @@
   const instructionsSectionID = uid();
 </script>
 
-<div class="absolute top-1 left-1 z-10 flex items-center">
-  <CloseIconButton href={backURL} />
-</div>
+<div class="w-full h-full flex flex-col pbsafe-8">
+  <div
+    use:sticky
+    class="flex flex-col sticky bg-base-500 top-0 z-10 px-4 md:px-8 lg:px-12 pb-4 ptsafe-4 transition-all stuck:shadow-md stuck:bg-base-600 stuck:ptsafe-0 stuck:-translate-y-6 md:stuck:translate-y-0 md:stuck:ptsafe-4"
+  >
+    <div
+      class="flex justify-between items-center mb-4 transition-transform stuck:scale-y-0 md:stuck:scale-y-100"
+    >
+      <a href={backURL} class="btn-link text-sm text-fg-muted flex items-center gap-1">
+        <IconLeft />
+        Back
+      </a>
+      <a
+        href={`/recipes/${id}/edit`}
+        class="btn-link text-sm text-fg-muted flex items-center gap-2"
+      >
+        Edit
+        <IconPencil />
+      </a>
+    </div>
 
-<div class="w-full h-full flex flex-col pb-8">
-  <div class="flex justify-between items-baseline px-4 md:px-8 lg:px-12 pb-8 pt-12">
-    <h1 class="text-3xl font-serif font-bold pr-4">
+    <h1 class="text-xl md:text-3xl font-serif font-bold">
       {recipe.title}
     </h1>
-
-    <a href={`/recipes/${id}/edit`} class="btn-link text-sm text-fg-muted">Edit</a>
   </div>
 
-  <div class="flex flex-col md:flex-row gap-8 px-4 md:px-8 lg:px-12">
+  <div class="flex flex-col md:flex-row gap-8 px-4 md:px-8 lg:px-12 mt-4">
     {#if recipe.image_id || (recipe.tags.length ?? 0) > 0 || recipe.rich_notes}
       <div class="flex-1 flex flex-col">
         {#if recipe.image_id}

--- a/ui/src/routes/recipes/[id]/edit/EditRecipePage.svelte
+++ b/ui/src/routes/recipes/[id]/edit/EditRecipePage.svelte
@@ -11,13 +11,13 @@
   import { handleSuperformError } from '$lib/error-to-superform';
   import InstructionsField from '$lib/components/recipes/form/InstructionsField.svelte';
   import { goto } from '$app/navigation';
-  import CloseIconButton from '$lib/components/CloseIconButton.svelte';
   import Button from '$lib/components/Button.svelte';
   import type { DetailedRecipe } from '$lib/types/recipe';
   import { useQueryClient } from '@tanstack/svelte-query';
   import { queryKeys } from '$lib/api/query-keys';
   import { useAuth } from '$lib/auth-context';
   import { uid } from 'uid';
+  import { sticky } from '$lib/actions/sticky';
 
   export let backURL: string;
   export let id: string;
@@ -69,15 +69,17 @@
   const instructionsSectionID = uid();
 </script>
 
-<div class="absolute top-1 left-1 z-10 flex items-center">
-  <CloseIconButton href={backURL} />
-</div>
+<form method="POST" use:enhance class="pbsafe-8">
+  <div
+    use:sticky
+    class="flex justify-between items-baseline sticky bg-base-500 top-0 z-10 px-4 md:px-8 lg:px-12 pb-4 ptsafe-4 md:ptsafe-8 transition-all stuck:shadow-md stuck:bg-base-600"
+  >
+    <h1 class="text-xl md:text-3xl font-serif font-bold">Edit Recipe</h1>
 
-<form method="POST" use:enhance class="pb-8">
-  <div class="flex justify-between mb-8 px-4 md:px-8 lg:px-12 pt-12">
-    <h1 class="font-bold text-3xl font-serif">Edit Recipe</h1>
-
-    <Button type="submit" class="btn-solid btn-primary" isLoading={$submitting}>Save</Button>
+    <div class="flex gap-2">
+      <a href={backURL} class="btn-solid btn-gray">Cancel</a>
+      <Button type="submit" class="btn-solid btn-primary" isLoading={$submitting}>Save</Button>
+    </div>
   </div>
 
   <div class="flex flex-col md:flex-row gap-8 px-4 md:px-8 lg:px-12">

--- a/ui/src/routes/recipes/new/+page.svelte
+++ b/ui/src/routes/recipes/new/+page.svelte
@@ -12,11 +12,11 @@
   import InstructionsField from '$lib/components/recipes/form/InstructionsField.svelte';
   import { goto } from '$app/navigation';
   import Button from '$lib/components/Button.svelte';
-  import CloseIconButton from '$lib/components/CloseIconButton.svelte';
   import { queryKeys } from '$lib/api/query-keys';
   import { useQueryClient } from '@tanstack/svelte-query';
   import { useAuth } from '$lib/auth-context';
   import { uid } from 'uid';
+  import { sticky } from '$lib/actions/sticky';
 
   const backURL = `/recipes?${localStorage.getItem('last-recipes-query')}`;
 
@@ -67,15 +67,17 @@
   const instructionsSectionID = uid();
 </script>
 
-<div class="absolute top-1 left-1 z-10 flex items-center">
-  <CloseIconButton href={backURL} />
-</div>
+<form method="POST" use:enhance class="pbsafe-8">
+  <div
+    use:sticky
+    class="flex justify-between items-baseline sticky bg-base-500 top-0 z-10 px-4 md:px-8 lg:px-12 pb-4 ptsafe-4 md:ptsafe-8 transition-all stuck:shadow-md stuck:bg-base-600"
+  >
+    <h1 class="text-xl md:text-3xl font-serif font-bold">Add Recipe</h1>
 
-<form method="POST" use:enhance class="pb-8">
-  <div class="flex justify-between items-baseline mb-8 px-4 md:px-8 lg:px-12 pt-12">
-    <h1 class="font-bold text-3xl font-serif">Add Recipe</h1>
-
-    <Button type="submit" class="btn-solid btn-primary" isLoading={$submitting}>Save</Button>
+    <div class="flex gap-2">
+      <a href={backURL} class="btn-solid btn-gray">Cancel</a>
+      <Button type="submit" class="btn-solid btn-primary" isLoading={$submitting}>Save</Button>
+    </div>
   </div>
 
   <div class="flex flex-col md:flex-row gap-8 px-4 md:px-8 lg:px-12">

--- a/ui/src/routes/settings/SettingsPage.svelte
+++ b/ui/src/routes/settings/SettingsPage.svelte
@@ -12,7 +12,7 @@
 
 <div class="w-full h-full">
   <div class="flex flex-col max-w-md mx-auto px-4 gap-8">
-    <div class="py-6">
+    <div class="ptsafe-6 pb-6">
       <h1 class="font-serif font-bold text-3xl mb-4">Settings</h1>
 
       <a href={backURL} class="flex items-center">

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,7 +1,30 @@
+import plugin from 'tailwindcss/plugin';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{html,js,svelte,ts}'],
   darkMode: 'selector',
+
+  plugins: [
+    plugin(function ({ addVariant }) {
+      addVariant('stuck', '&[data-stuck]');
+    }),
+
+    plugin(function ({ matchUtilities, theme }) {
+      matchUtilities(
+        {
+          pbsafe: (value) => ({
+            paddingBottom: `calc(env(safe-area-inset-bottom, 0px) + ${value})`,
+          }),
+          ptsafe: (value) => ({
+            paddingTop: `calc(env(safe-area-inset-top, 0px) + ${value})`,
+          }),
+        },
+        { values: theme('spacing') },
+      );
+    }),
+  ],
+
   theme: {
     colors: {
       food: {


### PR DESCRIPTION
Most pages use sticky headers now.

The list recipes header was redesigned to use a 3-dot action menu. The search is part of the main header on desktop. The footer of the page was removed.

Set page viewport to place content under the notch on iOS devices.